### PR TITLE
typo's after parsing academicyear

### DIFF
--- a/js/earhart-fellows/earhart-source.txt
+++ b/js/earhart-fellows/earhart-source.txt
@@ -10608,7 +10608,7 @@ Robert L. Pfaltzgraff Jr., Sponsor, M.A., 2002
 HAWLEY, Michael C. 
 Graduate Fellowship(s) 
 2012-2013 
-2103-2014 
+2013-2014 
 Duke University, Government/Politics, 
 Michael Allen Gillespie, Sponsor 
 Address,
@@ -25953,7 +25953,7 @@ W. Court Street, Seguin, TX 78155
 gwalsh@tlu.edu 
 WALSH, J. Richard 
 Graduate Fellowship(s) 
-1979-1080 
+1979-1980 
 1980-1981 
 1981-1982 
 University of South Carolina, International Studies, 


### PR DESCRIPTION
2 minor typo's after I've parsed academicyear and restructured the data with sponsors as the level of observation. 

Merging this here as my attempt to reorg the repo's failed miserably as there was a 100+mb file somewhere which jammed everything. Let me know if you're familiar with how to remove a file from the history of a repo.